### PR TITLE
Eliminate live API reads from MCP serve phase

### DIFF
--- a/internal/tools/resources.go
+++ b/internal/tools/resources.go
@@ -168,18 +168,6 @@ func (p *feedResourceProvider) readTags(
 		return nil, fmt.Errorf("building story store: %w", err)
 	}
 
-	userTags := make(map[string]int)
-	storyTags := make(map[string]int)
-
-	for _, rec := range p.stories.stories {
-		for _, t := range rec.UserTags {
-			userTags[t]++
-		}
-		for _, t := range rec.Tags {
-			storyTags[t]++
-		}
-	}
-
 	type tagEntry struct {
 		Tag   string `json:"tag"`
 		Count int    `json:"count"`
@@ -205,8 +193,8 @@ func (p *feedResourceProvider) readTags(
 		StoryTags    []tagEntry `json:"story_tags"`
 	}{
 		TotalStories: len(p.stories.stories),
-		UserTags:     sortedTags(userTags),
-		StoryTags:    sortedTags(storyTags),
+		UserTags:     sortedTags(p.stories.userTags),
+		StoryTags:    sortedTags(p.stories.storyTags),
 	}
 
 	data, err := json.MarshalIndent(resp, "", "  ")

--- a/internal/tools/resources.go
+++ b/internal/tools/resources.go
@@ -315,16 +315,55 @@ func (p *feedResourceProvider) readFeedStories(
 		return nil, fmt.Errorf("invalid feed ID: %s", feedID)
 	}
 
-	raw, err := p.client.StoriesFeed(ctx, id, 0, "", "", "")
+	if err := p.stories.ensureBuilt(); err != nil {
+		return nil, fmt.Errorf("building story store: %w", err)
+	}
+
+	type storySummary struct {
+		Hash      string   `json:"hash"`
+		Title     string   `json:"title"`
+		Authors   string   `json:"authors,omitempty"`
+		Date      string   `json:"date"`
+		Permalink string   `json:"permalink"`
+		Tags      []string `json:"tags,omitempty"`
+		UserTags  []string `json:"user_tags,omitempty"`
+	}
+
+	var matches []storySummary
+	for _, rec := range p.stories.stories {
+		if rec.FeedID == id {
+			matches = append(matches, storySummary{
+				Hash:      rec.Hash,
+				Title:     rec.Title,
+				Authors:   rec.Authors,
+				Date:      rec.Date.Format("2006-01-02 15:04:05"),
+				Permalink: rec.Permalink,
+				Tags:      rec.Tags,
+				UserTags:  rec.UserTags,
+			})
+		}
+	}
+
+	resp := struct {
+		FeedID  int            `json:"feed_id"`
+		Count   int            `json:"count"`
+		Stories []storySummary `json:"stories"`
+	}{
+		FeedID:  id,
+		Count:   len(matches),
+		Stories: matches,
+	}
+
+	data, err := json.MarshalIndent(resp, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("fetching stories: %w", err)
+		return nil, err
 	}
 
 	return &protocol.ResourceReadResult{
 		Contents: []protocol.ResourceContent{{
 			URI:      resourceURI,
 			MimeType: "application/json",
-			Text:     string(raw),
+			Text:     string(data),
 		}},
 	}, nil
 }
@@ -443,9 +482,9 @@ func (p *feedResourceProvider) readStoryOriginal(
 	ctx context.Context,
 	resourceURI, storyHash string,
 ) (*protocol.ResourceReadResult, error) {
-	raw, err := p.client.OriginalText(ctx, storyHash)
-	if err != nil {
-		return nil, fmt.Errorf("fetching original text: %w", err)
+	raw, ok := p.client.CachedOriginalText(storyHash)
+	if !ok {
+		return nil, fmt.Errorf("original text not in cache for story %s (run 'nebulous fetch' to populate)", storyHash)
 	}
 
 	return &protocol.ResourceReadResult{
@@ -674,7 +713,7 @@ func registerResources(
 		protocol.ResourceTemplate{
 			URITemplate: "nebulous://feed/{feed_id}/stories",
 			Name:        "Feed Stories",
-			Description: "Stories from a feed with full HTML content. Response is very large — delegate to a subagent.",
+			Description: "Starred stories from a feed, from local index. Returns compact summaries (hash, title, date, permalink, tags). No API call.",
 			MimeType:    "application/json",
 		},
 		nil,
@@ -704,7 +743,7 @@ func registerResources(
 		protocol.ResourceTemplate{
 			URITemplate: "nebulous://story/{story_hash}/original",
 			Name:        "Story Original Text",
-			Description: "Full original article text fetched from source URL. Use when story/{hash} shows has_content=false or content was truncated. Makes an HTTP request. Response can be very large — delegate to a subagent.",
+			Description: "Full original article text from local cache. Use when story/{hash} shows has_content=false or content was truncated. No API call — requires 'nebulous fetch' to have populated the cache. Response can be large — delegate to a subagent.",
 			MimeType:    "application/json",
 		},
 		nil,

--- a/internal/tools/story_store.go
+++ b/internal/tools/story_store.go
@@ -29,11 +29,13 @@ type storyRecord struct {
 }
 
 type storyStore struct {
-	client  *newsblur.Client
-	once    sync.Once
-	stories []*storyRecord
-	words   map[string][]*storyRecord
-	err     error
+	client    *newsblur.Client
+	once      sync.Once
+	stories   []*storyRecord
+	words     map[string][]*storyRecord
+	userTags  map[string]int
+	storyTags map[string]int
+	err       error
 }
 
 func newStoryStore(client *newsblur.Client) *storyStore {
@@ -43,6 +45,8 @@ func newStoryStore(client *newsblur.Client) *storyStore {
 func (s *storyStore) ensureBuilt() error {
 	s.once.Do(func() {
 		s.words = make(map[string][]*storyRecord)
+		s.userTags = make(map[string]int)
+		s.storyTags = make(map[string]int)
 		s.err = s.build()
 	})
 	return s.err
@@ -78,6 +82,16 @@ func (s *storyStore) build() error {
 
 			for word := range rec.Words {
 				s.words[word] = append(s.words[word], rec)
+			}
+			for _, t := range rec.UserTags {
+				if t != "" {
+					s.userTags[t]++
+				}
+			}
+			for _, t := range rec.Tags {
+				if t != "" {
+					s.storyTags[t]++
+				}
 			}
 		}
 


### PR DESCRIPTION
readFeedStories: query the in-memory story store by feed ID instead of
calling client.StoriesFeed (which hits /reader/feed/{id}).

readStoryOriginal: use client.CachedOriginalText (disk read, no TTL)
instead of client.OriginalText (live HTTP GET to /rss_feeds/original_text).

All MCP read paths now operate exclusively against the local persistent
store populated by 'nebulous fetch'. Only mutation tools (mark read/unread,
star/unstar, subscribe, folders, OPML) make live API calls.

https://claude.ai/code/session_011eC1HdqkkmwRREHfdBzUwq