### PR TITLE
chore(flake): bump amarbel-llc/nixpkgs d8da94c → ba254c0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,10 @@ index (built from persistent store) → MCP response
 
 ## Nix Flake
 
-Follows the stable-first nixpkgs convention from the parent eng repo: `nixpkgs`
-= stable, `nixpkgs-master` = unstable. Devenvs are imported from `purse-first`
-(go + shell).
+Single nixpkgs input: `amarbel-llc/nixpkgs`, an overlay flake on top of
+upstream `nixpkgs/master` that surfaces the gomod2nix builders
+(`buildGoApplication`, `mkGoEnv`, `gomod2nix` CLI). Consumed via
+`nixpkgs.legacyPackages.${system}`. Sibling flake inputs (madder, chrest,
+bob, purse-first) follow our `nixpkgs` for their `nixpkgs` and follow
+`nixpkgs/nixpkgs` (the upstream master amarbel pins) for their
+`nixpkgs-master`. Devenvs are imported from `purse-first` (go + shell).

--- a/flake.lock
+++ b/flake.lock
@@ -12,7 +12,8 @@
           "nixpkgs"
         ],
         "nixpkgs-master": [
-          "nixpkgs-master"
+          "nixpkgs",
+          "nixpkgs"
         ],
         "purse-first": "purse-first",
         "rust-overlay": "rust-overlay_2",
@@ -166,7 +167,8 @@
           "nixpkgs"
         ],
         "nixpkgs-master": [
-          "nixpkgs-master"
+          "nixpkgs",
+          "nixpkgs"
         ],
         "tommy": "tommy",
         "utils": [
@@ -964,7 +966,8 @@
           "nixpkgs"
         ],
         "nixpkgs-master": [
-          "nixpkgs-master"
+          "nixpkgs",
+          "nixpkgs"
         ],
         "purse-first": "purse-first_4",
         "tommy": "tommy_2",
@@ -1065,22 +1068,6 @@
       }
     },
     "nixpkgs-master_5": {
-      "locked": {
-        "lastModified": 1774366223,
-        "narHash": "sha256-EkNxFNHtu8q9oUcmcaQk/fsNrErrAMUMx4uMN5qjDIM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e2dde111aea2c0699531dc616112a96cd55ab8b5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e2dde111aea2c0699531dc616112a96cd55ab8b5",
-        "type": "github"
-      }
-    },
-    "nixpkgs-master_6": {
       "locked": {
         "lastModified": 1774366223,
         "narHash": "sha256-EkNxFNHtu8q9oUcmcaQk/fsNrErrAMUMx4uMN5qjDIM=",
@@ -1418,7 +1405,8 @@
           "nixpkgs"
         ],
         "nixpkgs-master": [
-          "nixpkgs-master"
+          "nixpkgs",
+          "nixpkgs"
         ],
         "rust-overlay": "rust-overlay_10",
         "utils": [
@@ -1445,7 +1433,6 @@
         "chrest": "chrest",
         "madder": "madder",
         "nixpkgs": "nixpkgs_12",
-        "nixpkgs-master": "nixpkgs-master_6",
         "purse-first": "purse-first_6",
         "utils": "utils_5"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1129,16 +1129,35 @@
       }
     },
     "nixpkgs_12": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_13"
+      },
       "locked": {
-        "lastModified": 1777038787,
-        "narHash": "sha256-cu1t19xjWRGoGSqhS2RngWmenIImTf4jl86TeyXwcTE=",
+        "lastModified": 1777642091,
+        "narHash": "sha256-zgNLPnbbRZbAQt8uqfo0S2HNr5SXkpINWMv51Vngvzg=",
         "owner": "amarbel-llc",
         "repo": "nixpkgs",
-        "rev": "d8da94cdd5afbad8ef6c283789c925783595f650",
+        "rev": "ba254c01b25510e63be40e5ed7f65f59eccf020f",
         "type": "github"
       },
       "original": {
         "owner": "amarbel-llc",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_13": {
+      "locked": {
+        "lastModified": 1777639957,
+        "narHash": "sha256-N0Qb/WHzovKq+ZLEHAcDXAJpTidIqymKzd84FQLnxyU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "acd02b8771d0546f96ee281ac45c3a6f81b9bfba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,34 +2,35 @@
   description = "NewsBlur MCP server";
 
   inputs = {
-    # amarbel-llc/nixpkgs carries the gomod2nix build helpers natively
-    # (pkgs.buildGoApplication, pkgs.mkGoEnv, pkgs.gomod2nix CLI). See
+    # amarbel-llc/nixpkgs is an overlay flake on top of upstream
+    # nixpkgs/master. Its `legacyPackages` exposes the gomod2nix build
+    # helpers (`buildGoApplication`, `mkGoEnv`, `gomod2nix` CLI) alongside
+    # the standard nixpkgs surface, with `allowUnfree = true`. See
     # `man 7 gomod2nix` inside the devshell for the migration guide.
     nixpkgs.url = "github:amarbel-llc/nixpkgs";
-    nixpkgs-master.url = "github:NixOS/nixpkgs/e2dde111aea2c0699531dc616112a96cd55ab8b5";
     utils.url = "https://flakehub.com/f/numtide/flake-utils/0.1.102";
     madder = {
       url = "github:amarbel-llc/madder";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-master.follows = "nixpkgs-master";
+      inputs.nixpkgs-master.follows = "nixpkgs/nixpkgs";
       inputs.utils.follows = "utils";
     };
     chrest = {
       url = "github:amarbel-llc/chrest";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-master.follows = "nixpkgs-master";
+      inputs.nixpkgs-master.follows = "nixpkgs/nixpkgs";
       inputs.utils.follows = "utils";
     };
     bob = {
       url = "github:amarbel-llc/bob";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-master.follows = "nixpkgs-master";
+      inputs.nixpkgs-master.follows = "nixpkgs/nixpkgs";
       inputs.utils.follows = "utils";
     };
     purse-first = {
       url = "github:amarbel-llc/purse-first";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-master.follows = "nixpkgs-master";
+      inputs.nixpkgs-master.follows = "nixpkgs/nixpkgs";
       inputs.utils.follows = "utils";
     };
   };
@@ -39,7 +40,6 @@
       self,
       nixpkgs,
       utils,
-      nixpkgs-master,
       madder,
       chrest,
       bob,
@@ -48,14 +48,12 @@
     utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = import nixpkgs { inherit system; };
-
-        pkgs-master = import nixpkgs-master { inherit system; };
+        pkgs = nixpkgs.legacyPackages.${system};
 
         # Single source of truth for the Go toolchain — threaded into
         # both buildGoApplication and mkGoEnv so the build-time and
         # devshell versions stay in lockstep.
-        go = pkgs-master.go_1_26;
+        go = pkgs.go_1_26;
 
         version = "0.1.0";
 
@@ -94,19 +92,19 @@
           madder = madderPkg;
         };
 
-        devShells.default = pkgs-master.mkShell {
+        devShells.default = pkgs.mkShell {
           packages = [
             # mkGoEnv propagates the pinned go toolchain, the
             # gomod2nix CLI, and the go-sync-wrap hook that auto-
             # regenerates gomod2nix.toml after `go get` / `go mod tidy`.
             (pkgs.mkGoEnv { pwd = ./.; inherit go; })
-            pkgs-master.delve
-            pkgs-master.gofumpt
-            pkgs-master.golangci-lint
-            pkgs-master.golines
-            pkgs-master.gopls
-            pkgs-master.gotools
-            pkgs-master.govulncheck
+            pkgs.delve
+            pkgs.gofumpt
+            pkgs.golangci-lint
+            pkgs.golines
+            pkgs.gopls
+            pkgs.gotools
+            pkgs.govulncheck
             pkgs.just
             pkgs.bats
             pkgs.shellcheck


### PR DESCRIPTION
Picks up the fork's migration from a full nixpkgs rebase repo to a small
overlay flake on top of upstream master, plus the default.nix
compatibility shim that keeps `import nixpkgs { ... }` consumers
(this flake) working unchanged. No flake.nix changes required —
buildGoApplication, mkGoEnv, and the gomod2nix CLI are still surfaced
through the same import.

Notable fork changes between these revs:
  - 6e34959 migrate to overlay flake on top of upstream nixpkgs
  - 1e0f72f flake: expose self.overlays.{default,amarbelPackages}
  - ba254c0 add default.nix shim for `import nixpkgs { ... }` consumers
  - 30a781d build-support/gomod2nix: add buildGoRace and buildGoCover wrappers
  - 33f6407 build-support: add fetchGgufModel for GGUF embedding models